### PR TITLE
Move non-graphical dependencies to express install

### DIFF
--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -12,49 +12,16 @@ resources:
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
   - name: RP-1-ExpressInstall
-  - name: ModuleManager
-  - name: KSPCommunityFixes
-  - name: KSPBurst-Full
   - name: Parallax-StockTextures
   - name: Parallax
   - name: Scatterer-sunflare-default
   - name: Scatterer-config
   - name: Scatterer
   - name: RSSTextures16K
-  - name: ReStock
-  - name: ReStockPlus
-  - any_of:
-    - name: RP-1
-    - name: RP-0
-    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
-  - name: RSSDateTimeFormatter
-  - name: ROEngines
-  - name: ROHeatshields
-  - name: ROTanks
-  - name: ROCapsules
-  - name: ROSolar
-  - name: B9-PWings-Fork
-  - name: KSPWheel
-  - name: KerbalRenamer
-  - name: KSCSwitcher
-  - name: AtmosphereAutopilot
-  - name: ProceduralFairings
-  - name: ProceduralParts
-  - name: RCSBuildAid
-  - name: RealAntennas
-  - name: TestFlight
-  - name: TextureReplacer
-  - name: MechJeb2
-  - name: Waterfall
-  - name: HangerExtenderExtended
-  - name: ModularLaunchPads
-  - name: RealSolarSystem
   - name: RSSVE-HR
   - name: DistantObject
   - name: PlanetShine
   - name: CanaveralPads
-  - name: ConformalDecals
-  - name: Shabby
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:

--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -11,7 +11,7 @@ resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/190040-*
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
-  - name: RP-1-ExpressInstall
+  - name: ModuleManager
   - name: Parallax-StockTextures
   - name: Parallax
   - name: Scatterer-sunflare-default
@@ -22,10 +22,13 @@ depends:
   - name: DistantObject
   - name: PlanetShine
   - name: CanaveralPads
+  - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:
   - name: RP-1-ExpressInstall-Graphics
+  - name: Ecumenopolis
+  - name: DistantObject-RealSolarSystem
 install:
   - find: RP-1-ExpressInstall-Graphics
     install_to: GameData

--- a/RP-1-ExpressInstall-Graphics-Low.netkan
+++ b/RP-1-ExpressInstall-Graphics-Low.netkan
@@ -11,8 +11,9 @@ resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/190040-*
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
-  - name: RP-1-ExpressInstall
+  - name: ModuleManager
   - name: RSSTextures4096
+  - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:

--- a/RP-1-ExpressInstall-Graphics-Low.netkan
+++ b/RP-1-ExpressInstall-Graphics-Low.netkan
@@ -12,40 +12,7 @@ resources:
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
   - name: RP-1-ExpressInstall
-  - name: ModuleManager
-  - name: KSPCommunityFixes
-  - name: KSPBurst-Full
   - name: RSSTextures4096
-  - name: ReStock
-  - name: ReStockPlus
-  - any_of:
-    - name: RP-1
-    - name: RP-0
-    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
-  - name: RSSDateTimeFormatter
-  - name: ROEngines
-  - name: ROHeatshields
-  - name: ROTanks
-  - name: ROCapsules
-  - name: ROSolar
-  - name: B9-PWings-Fork
-  - name: KSPWheel
-  - name: KerbalRenamer
-  - name: KSCSwitcher
-  - name: AtmosphereAutopilot
-  - name: ProceduralFairings
-  - name: ProceduralParts
-  - name: RCSBuildAid
-  - name: RealAntennas
-  - name: TestFlight
-  - name: TextureReplacer
-  - name: MechJeb2
-  - name: Waterfall
-  - name: HangerExtenderExtended
-  - name: ModularLaunchPads
-  - name: RealSolarSystem
-  - name: ConformalDecals
-  - name: Shabby
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:

--- a/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -12,46 +12,13 @@ resources:
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
   - name: RP-1-ExpressInstall
-  - name: ModuleManager
-  - name: KSPCommunityFixes
-  - name: KSPBurst-Full
   - name: Scatterer-sunflare-default
   - name: Scatterer-config
   - name: Scatterer
   - name: RSSTextures8192
-  - name: ReStock
-  - name: ReStockPlus
-  - any_of:
-    - name: RP-1
-    - name: RP-0
-    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
-  - name: RSSDateTimeFormatter
-  - name: ROEngines
-  - name: ROHeatshields
-  - name: ROTanks
-  - name: ROCapsules
-  - name: ROSolar
-  - name: B9-PWings-Fork
-  - name: KSPWheel
-  - name: KerbalRenamer
-  - name: KSCSwitcher
-  - name: AtmosphereAutopilot
-  - name: ProceduralFairings
-  - name: ProceduralParts
-  - name: RCSBuildAid
-  - name: RealAntennas
-  - name: TestFlight
-  - name: TextureReplacer
-  - name: MechJeb2
-  - name: Waterfall
-  - name: HangerExtenderExtended
-  - name: ModularLaunchPads
-  - name: RealSolarSystem
   - name: RSSVE-LR
   - name: DistantObject
   - name: PlanetShine
-  - name: ConformalDecals
-  - name: Shabby
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:

--- a/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -11,7 +11,7 @@ resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/190040-*
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
-  - name: RP-1-ExpressInstall
+  - name: ModuleManager
   - name: Scatterer-sunflare-default
   - name: Scatterer-config
   - name: Scatterer
@@ -19,10 +19,13 @@ depends:
   - name: RSSVE-LR
   - name: DistantObject
   - name: PlanetShine
+  - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics
 conflicts:
   - name: RP-1-ExpressInstall-Graphics
+  - name: Ecumenopolis
+  - name: DistantObject-RealSolarSystem
 install:
   - find: RP-1-ExpressInstall-Graphics
     install_to: GameData


### PR DESCRIPTION
Currently, the express install package asks you to select a graphics preset, and it is the graphics preset metapackage that does the real "meat and potatoes" of installing ROEngines, ROTanks, etc. In conjunction with [this "sister" PR](https://github.com/KSP-RO/RP-1-ExpressInstall/pull/2), I would like to move the non-graphical dependencies out of the preset metapackages and into the express install itself. The other PR has more information.