### PR TITLE
Recommendation suppression property for netkans

### DIFF
--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -13,15 +13,25 @@ resources:
 depends:
   - name: ModuleManager
   - name: Parallax-StockTextures
+    suppress_recommendations: true
   - name: Parallax
+    suppress_recommendations: true
   - name: Scatterer-sunflare-default
+    suppress_recommendations: true
   - name: Scatterer-config
+    suppress_recommendations: true
   - name: Scatterer
+    suppress_recommendations: true
   - name: RSSTextures16K
+    suppress_recommendations: true
   - name: RSSVE-HR
+    suppress_recommendations: true
   - name: DistantObject
+    suppress_recommendations: true
   - name: PlanetShine
+    suppress_recommendations: true
   - name: CanaveralPads
+    suppress_recommendations: true
   - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics

--- a/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -13,12 +13,19 @@ resources:
 depends:
   - name: ModuleManager
   - name: Scatterer-sunflare-default
+    suppress_recommendations: true
   - name: Scatterer-config
+    suppress_recommendations: true
   - name: Scatterer
+    suppress_recommendations: true
   - name: RSSTextures8192
+    suppress_recommendations: true
   - name: RSSVE-LR
+    suppress_recommendations: true
   - name: DistantObject
+    suppress_recommendations: true
   - name: PlanetShine
+    suppress_recommendations: true
   - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics


### PR DESCRIPTION
Hi!

This is a pending follow-up item for KSP-CKAN/CKAN#3892.

Sometime in the next 3 months or so, there will most likely be a new CKAN client release featuring "deep recommendations", where all the dependencies in a changeset will contribute recommendations and suggestions, instead of just what the user clicks on.

This pull request applies the `suppress_recommendations` property to suppress this behavior for affected KSP-RO netkans.

Cheers!
