### PR TITLE
Move CanaveralPads from required in high graphics to recommended across all express installs

### DIFF
--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -30,8 +30,6 @@ depends:
     suppress_recommendations: true
   - name: PlanetShine
     suppress_recommendations: true
-  - name: CanaveralPads
-    suppress_recommendations: true
   - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics


### PR DESCRIPTION
There are 2 reasons for this change:
- CanaveralPads is not a very taxing mod, so there is no real need to limit it only to the high graphics version of the express install.
- Not all High Graphics Express Install users are going to play at the KSC in Cape Canaveral, in which case having this mod required is a waste of resources and storage.

Should be done with: https://github.com/KSP-RO/RP-1-ExpressInstall/pull/9