### PR TITLE
Remove planetshine from express graphics due to adding deferred into express

### DIFF
--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -28,8 +28,6 @@ depends:
     suppress_recommendations: true
   - name: DistantObject
     suppress_recommendations: true
-  - name: PlanetShine
-    suppress_recommendations: true
   - name: CanaveralPads
     suppress_recommendations: true
   - name: RP-1-ExpressInstall

--- a/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -24,8 +24,6 @@ depends:
     suppress_recommendations: true
   - name: DistantObject
     suppress_recommendations: true
-  - name: PlanetShine
-    suppress_recommendations: true
   - name: RP-1-ExpressInstall
 provides:
   - RP-1-ExpressInstall-Graphics


### PR DESCRIPTION
Planetshine default settings are redundant with deferred, so assuming that https://github.com/KSP-RO/RP-1-ExpressInstall/pull/10 is merged, it will no longer be useful in express installs.

Fixes https://github.com/KSP-RO/RP-1-ExpressInstall/issues/7
Deferred is still listed as incompatible with Procedural Fairings and Procedural Parts (and therefore Express) due to https://github.com/KSP-RO/ProceduralFairings/issues/59, so this will remain as a draft PR (its barely an incompatibility though...)