### PR TITLE
Allow users to choose which scatterer sunflare they want

### DIFF
--- a/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/RP-1-ExpressInstall-Graphics-High.netkan
@@ -16,8 +16,6 @@ depends:
     suppress_recommendations: true
   - name: Parallax
     suppress_recommendations: true
-  - name: Scatterer-sunflare-default
-    suppress_recommendations: true
   - name: Scatterer-config
     suppress_recommendations: true
   - name: Scatterer

--- a/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -12,8 +12,6 @@ resources:
   repository: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics
 depends:
   - name: ModuleManager
-  - name: Scatterer-sunflare-default
-    suppress_recommendations: true
   - name: Scatterer-config
     suppress_recommendations: true
   - name: Scatterer


### PR DESCRIPTION
This PR restores the option for Express users to be able to pick which scatterer sunflare config they want, instead of being forced into the (imo, pretty bland) default scatterer sunflare. If this is merged, I will make a note on the wiki instructing people to choose the scatterer sunflare if they don't know what to choose from, to prevent any possible confusion. (as is already done when the user is prompted to pick a choice in other parts of the express install)